### PR TITLE
#6 | states for ongoing race

### DIFF
--- a/src/app/components/horse-race-ui/horse-race-ui.component.html
+++ b/src/app/components/horse-race-ui/horse-race-ui.component.html
@@ -1,7 +1,7 @@
 <div class="c-horse-race">
     <div *ngFor="let horse of horses" class="c-horse-race__horse-track">
         <label>Horse {{ horse.index }} — {{ horse.position }}m</label>
-        <br>
+        <br />
         <input
             type="range"
             [min]="0"
@@ -9,21 +9,23 @@
             [value]="horse.position"
             disabled
         />
-        <br><br>
+        <br /><br />
     </div>
 
     <div class="c-horse-race__subtitle">Race Distance: {{ finalPosition }}m</div>
     <br />
-    <button class="c-horse-race__button" (click)="restartRace()">Restart Race</button>
 
-    <br /><br />
+    <div *ngIf="raceState === 'post'" class="c-horse-race__post-ui">
+        <button class="c-horse-race__button" (click)="restartRace()">Restart Race</button>
+        <br /><br />
 
-    <div class="c-horse-race__race-result">
-        <div class="c-horse-race__subtitle">🏆 Final Standings:</div>
-        <ol>
-            <li *ngFor="let h of podium">
-                Horse {{ h.index }} ({{ h.position }})
-            </li>
-        </ol>
+        <div class="c-horse-race__race-result">
+            <div class="c-horse-race__subtitle">🏆 Final Standings:</div>
+            <ol>
+                <li *ngFor="let h of podium">
+                    Horse {{ h.index }} ({{ h.position }})
+                </li>
+            </ol>
+        </div>
     </div>
 </div>

--- a/src/app/components/horse-race-ui/horse-race-ui.component.html
+++ b/src/app/components/horse-race-ui/horse-race-ui.component.html
@@ -13,19 +13,4 @@
     </div>
 
     <div class="c-horse-race__subtitle">Race Distance: {{ finalPosition }}m</div>
-    <br />
-
-    <div *ngIf="raceState === 'post'" class="c-horse-race__post-ui">
-        <button class="c-horse-race__button" (click)="restartRace()">Restart Race</button>
-        <br /><br />
-
-        <div class="c-horse-race__race-result">
-            <div class="c-horse-race__subtitle">🏆 Final Standings:</div>
-            <ol>
-                <li *ngFor="let h of podium">
-                    Horse {{ h.index }} ({{ h.position }})
-                </li>
-            </ol>
-        </div>
-    </div>
 </div>

--- a/src/app/components/horse-race-ui/horse-race-ui.component.ts
+++ b/src/app/components/horse-race-ui/horse-race-ui.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { RaceService } from '@app/services/game/race.service';
+import { OngoingRaceService } from '@app/services/game/ongoing-race.service';
 import { Subscription } from 'rxjs';
 
 @Component({
@@ -18,13 +18,13 @@ export class HorseRaceUiComponent implements OnInit, OnDestroy {
 
     private sub = new Subscription();
 
-    constructor(private raceService: RaceService) {}
+    constructor(private ongoingRaceService: OngoingRaceService) {}
 
     ngOnInit(): void {
-        this.sub.add(this.raceService.horses$.subscribe(h => this.horses = h));
-        this.sub.add(this.raceService.winner$.subscribe(w => this.winner = w));
-        this.sub.add(this.raceService.podium$.subscribe(p => this.podium = p));
-        this.sub.add(this.raceService.finalPosition$.subscribe(fp => this.finalPosition = fp));
+        this.sub.add(this.ongoingRaceService.horses$.subscribe(h => this.horses = h));
+        this.sub.add(this.ongoingRaceService.winner$.subscribe(w => this.winner = w));
+        this.sub.add(this.ongoingRaceService.podium$.subscribe(p => this.podium = p));
+        this.sub.add(this.ongoingRaceService.finalPosition$.subscribe(fp => this.finalPosition = fp));
     }
 
     ngOnDestroy(): void {
@@ -32,6 +32,6 @@ export class HorseRaceUiComponent implements OnInit, OnDestroy {
     }
 
     restartRace(): void {
-        this.raceService.restartRace();
+        this.ongoingRaceService.restartRace();
     }
 }

--- a/src/app/components/horse-race-ui/horse-race-ui.component.ts
+++ b/src/app/components/horse-race-ui/horse-race-ui.component.ts
@@ -15,6 +15,7 @@ export class HorseRaceUiComponent implements OnInit, OnDestroy {
     winner: any = null;
     podium: any[] = [];
     finalPosition = 0;
+    raceState: 'pre' | 'in' | 'post' = 'pre';
 
     private sub = new Subscription();
 
@@ -25,6 +26,7 @@ export class HorseRaceUiComponent implements OnInit, OnDestroy {
         this.sub.add(this.ongoingRaceService.winner$.subscribe(w => this.winner = w));
         this.sub.add(this.ongoingRaceService.podium$.subscribe(p => this.podium = p));
         this.sub.add(this.ongoingRaceService.finalPosition$.subscribe(fp => this.finalPosition = fp));
+        this.sub.add(this.ongoingRaceService.raceState$.subscribe(rs => this.raceState = rs));
     }
 
     ngOnDestroy(): void {
@@ -32,6 +34,6 @@ export class HorseRaceUiComponent implements OnInit, OnDestroy {
     }
 
     restartRace(): void {
-        this.ongoingRaceService.restartRace();
+        this.ongoingRaceService.restartOngoingRace();
     }
 }

--- a/src/app/components/horse-race-ui/horse-race-ui.component.ts
+++ b/src/app/components/horse-race-ui/horse-race-ui.component.ts
@@ -12,10 +12,7 @@ import { Subscription } from 'rxjs';
 })
 export class HorseRaceUiComponent implements OnInit, OnDestroy {
     horses: any[] = [];
-    winner: any = null;
-    podium: any[] = [];
     finalPosition = 0;
-    raceState: 'pre' | 'in' | 'post' = 'pre';
 
     private sub = new Subscription();
 
@@ -23,17 +20,10 @@ export class HorseRaceUiComponent implements OnInit, OnDestroy {
 
     ngOnInit(): void {
         this.sub.add(this.ongoingRaceService.horses$.subscribe(h => this.horses = h));
-        this.sub.add(this.ongoingRaceService.winner$.subscribe(w => this.winner = w));
-        this.sub.add(this.ongoingRaceService.podium$.subscribe(p => this.podium = p));
         this.sub.add(this.ongoingRaceService.finalPosition$.subscribe(fp => this.finalPosition = fp));
-        this.sub.add(this.ongoingRaceService.raceState$.subscribe(rs => this.raceState = rs));
     }
 
     ngOnDestroy(): void {
         this.sub.unsubscribe();
-    }
-
-    restartRace(): void {
-        this.ongoingRaceService.restartOngoingRace();
     }
 }

--- a/src/app/pages/races/ongoing/ongoing.component.html
+++ b/src/app/pages/races/ongoing/ongoing.component.html
@@ -1,8 +1,29 @@
 <div class="p-ongoing">
-    <app-phaser-canvas [useHorse1]="useHorse1" />
-    <label for="useHorse1">Use Horse 1</label>
-    <input id="useHorse1" type="checkbox" [(ngModel)]="useHorse1" />
+    <div *ngIf="raceState === 'pre'" class="p-ongoing__pre">
+        <div class="p-ongoing__top">
+            <p>*canvas art*</p>
+            <h2>🏁 Race Starting Soon</h2>
+            <p>Countdown: {{ countdown }}s</p>
+        </div>
+    </div>
 
-    <br><br>
-    <app-horse-race-ui />
+    <div *ngIf="raceState === 'in'" class="p-ongoing__in">
+        <div class="p-ongoing__top">
+            <app-phaser-canvas [useHorse1]="useHorse1" />
+            <label for="useHorse1">Use Horse 1</label>
+            <input id="useHorse1" type="checkbox" [(ngModel)]="useHorse1" />
+        </div>
+    </div>
+
+    <div *ngIf="raceState === 'post'" class="p-ongoing__post">
+        <div class="p-ongoing__top">
+            <p>*canvas art*</p>
+            <h2>🏆 Race Complete</h2>
+            <p>The race has finished!</p>
+        </div>
+    </div>
+
+    <div class="p-ongoing__bottom">
+        <app-horse-race-ui />
+    </div>
 </div>

--- a/src/app/pages/races/ongoing/ongoing.component.html
+++ b/src/app/pages/races/ongoing/ongoing.component.html
@@ -19,7 +19,16 @@
         <div class="p-ongoing__top">
             <p>*canvas art*</p>
             <h2>🏆 Race Complete</h2>
-            <p>The race has finished!</p>
+            <p>Next race starts in {{ countdown }}s</p>
+
+            <div class="p-ongoing__podium">
+                <h3>🥇 Final Standings</h3>
+                <ol>
+                    <li *ngFor="let h of podium">
+                        Horse {{ h.index }} — {{ h.position }}m
+                    </li>
+                </ol>
+            </div>
         </div>
     </div>
 

--- a/src/app/pages/races/ongoing/ongoing.component.scss
+++ b/src/app/pages/races/ongoing/ongoing.component.scss
@@ -16,4 +16,8 @@
     &__button {
         @include button-0
     }
+
+    &__top{
+        @include container-border
+    }
 }

--- a/src/app/pages/races/ongoing/ongoing.component.ts
+++ b/src/app/pages/races/ongoing/ongoing.component.ts
@@ -22,17 +22,21 @@ import { Subscription } from 'rxjs';
 })
 export class OngoingComponent implements OnInit, OnDestroy {
     useHorse1 = true;
+    raceState: 'pre' | 'in' | 'post' = 'pre';
+    countdown = 0;
 
     private sub = new Subscription();
 
     constructor(private ongoingRaceService: OngoingRaceService) {}
 
     ngOnInit(): void {
-        this.ongoingRaceService.startRace();
+        this.ongoingRaceService.startOngoingRace();
+        this.sub.add(this.ongoingRaceService.raceState$.subscribe(state => this.raceState = state));
+        this.sub.add(this.ongoingRaceService.countdown$.subscribe(c => this.countdown = c));
     }
 
     ngOnDestroy(): void {
         this.sub.unsubscribe();
-        this.ongoingRaceService.stopRace();
+        this.ongoingRaceService.stopOngoingRace();
     }
 }

--- a/src/app/pages/races/ongoing/ongoing.component.ts
+++ b/src/app/pages/races/ongoing/ongoing.component.ts
@@ -4,7 +4,7 @@ import { FormsModule } from '@angular/forms';
 import { SharedModule } from '@app/shared/shared.module';
 import { PhaserCanvasComponent } from '@app/components/phaser-canvas/phaser-canvas.component';
 import { HorseRaceUiComponent } from '@app/components/horse-race-ui/horse-race-ui.component';
-import { RaceService } from '@app/services/game/race.service';
+import { OngoingRaceService } from '@app/services/game/ongoing-race.service';
 import { Subscription } from 'rxjs';
 
 @Component({
@@ -25,14 +25,14 @@ export class OngoingComponent implements OnInit, OnDestroy {
 
     private sub = new Subscription();
 
-    constructor(private raceService: RaceService) {}
+    constructor(private ongoingRaceService: OngoingRaceService) {}
 
     ngOnInit(): void {
-        this.raceService.startRace();
+        this.ongoingRaceService.startRace();
     }
 
     ngOnDestroy(): void {
         this.sub.unsubscribe();
-        this.raceService.stopRace();
+        this.ongoingRaceService.stopRace();
     }
 }

--- a/src/app/pages/races/ongoing/ongoing.component.ts
+++ b/src/app/pages/races/ongoing/ongoing.component.ts
@@ -24,6 +24,7 @@ export class OngoingComponent implements OnInit, OnDestroy {
     useHorse1 = true;
     raceState: 'pre' | 'in' | 'post' = 'pre';
     countdown = 0;
+    podium: any[] = [];
 
     private sub = new Subscription();
 
@@ -33,6 +34,7 @@ export class OngoingComponent implements OnInit, OnDestroy {
         this.ongoingRaceService.startOngoingRace();
         this.sub.add(this.ongoingRaceService.raceState$.subscribe(state => this.raceState = state));
         this.sub.add(this.ongoingRaceService.countdown$.subscribe(c => this.countdown = c));
+        this.sub.add(this.ongoingRaceService.podium$.subscribe(p => this.podium = p));
     }
 
     ngOnDestroy(): void {

--- a/src/app/services/game/ongoing-race.service.ts
+++ b/src/app/services/game/ongoing-race.service.ts
@@ -2,7 +2,7 @@ import { Injectable, OnDestroy } from '@angular/core';
 import { BehaviorSubject, interval, Subscription } from 'rxjs';
 
 @Injectable({ providedIn: 'root' })
-export class RaceService implements OnDestroy {
+export class OngoingRaceService implements OnDestroy {
     private readonly tickSpeed = 400;
     private readonly winningDistance = 1000;
     private raceInterval$!: Subscription;


### PR DESCRIPTION
# Fix #6 

## Description

- `race.service` renamed to `ongoing-race.service`
- `raceState` added (`pre` | `in` | `post`) reprscenting the ongoing race lifecycle
- New countdown class used for a `preTimer` (for the initial lapse before the actual race starts) and a `postTimer` (to restart the lifecycle automatically)
- UI adjusted to react based on the states and display the new data reactively. 

*pre state*
<img src="https://github.com/user-attachments/assets/8fd6c357-63b8-40ab-9089-bcfcf4da35ab" width="200">

*in state*
<img src="https://github.com/user-attachments/assets/7eb54c79-2a57-49e9-9fdd-bce2bff02687" width="200">

*post state*
<img src="https://github.com/user-attachments/assets/53d64d90-9e19-4c67-a2f1-e96838f05987" width="200">